### PR TITLE
Clean up WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@
 
 workspace(name = "com_google_mpact-sim")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 # Additional bazel rules.
 http_archive(
@@ -29,22 +29,23 @@ http_archive(
 )
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
 bazel_skylib_workspace()
 
 # Google Absail.
 http_archive(
     name = "com_google_absl",
     sha256 = "3ea49a7d97421b88a8c48a0de16c16048e17725c7ec0f1d3ea2683a2a75adc21",
+    strip_prefix = "abseil-cpp-20230125.0",
     urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.0.tar.gz"],
-    strip_prefix="abseil-cpp-20230125.0",
 )
 
 # Google protobuf.
 http_archive(
     name = "com_google_protobuf",
     sha256 = "4eab9b524aa5913c6fffb20b2a8abf5ef7f95a80bc0701f3a6dbb4c607f73460",
+    strip_prefix = "protobuf-3.21.12",
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protobuf-cpp-3.21.12.tar.gz"],
-    strip_prefix="protobuf-3.21.12",
 )
 
 # Bazel rules for proto.
@@ -55,24 +56,26 @@ http_archive(
     urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.3.0.tar.gz"],
 )
 
-load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_toolchains", "rules_proto_grpc_repos")
+load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")
+
 rules_proto_grpc_toolchains()
+
 rules_proto_grpc_repos()
 
 # Google test.
 http_archive(
     name = "com_google_googletest",
-    strip_prefix = "googletest-1.13.0",
     sha256 = "ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363",
+    strip_prefix = "googletest-1.13.0",
     urls = ["https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz"],
 )
 
 # ELFIO header based library.
 http_archive(
-    build_file = "BUILD.elfio",
     name = "com_github_serge1_elfio",
-    strip_prefix = "elfio-3.9",
+    build_file = "BUILD.elfio",
     sha256 = "767b269063fc35aba6d361139f830aa91c45dc6b77942f082666876c1aa0be0f",
+    strip_prefix = "elfio-3.9",
     urls = ["https://github.com/serge1/ELFIO/releases/download/Release_3.9/elfio-3.9.tar.gz"],
 )
 
@@ -114,15 +117,12 @@ http_archive(
 )
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+
 rules_foreign_cc_dependencies()
 
 # Additional rules for licenses
 http_archive(
     name = "rules_license",
     sha256 = "6157e1e68378532d0241ecd15d3c45f6e5cfd98fc10846045509fb2a7cc9e381",
-    url = "https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz"
+    url = "https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz",
 )
-
-load("@rules_license//:deps.bzl", "rules_license_dependencies")
-rules_license_dependencies()
-


### PR DESCRIPTION
* Remove the unused repository from `rules_license_dependencies()`
* Format the WORKSPACE file with buildifier (https://github.com/bazelbuild/buildtools/tree/master/buildifier)