### PR TITLE
Use Ninja generator to build antlr4 runtime

### DIFF
--- a/external/BUILD.antlr4
+++ b/external/BUILD.antlr4
@@ -27,6 +27,9 @@ cmake(
     cache_entries = {
         "CMAKE_CXX_FLAGS": "-std=c++17",
     },
+    generate_args = [
+        "-G Ninja",
+    ],
     lib_source = ":all_srcs",
     tags = ["requires-network"],
     out_static_libs = ["libantlr4-runtime.a"],


### PR DESCRIPTION
Turn on the parallel build by default from ninja and cut the build time from 240s to 40s