### PR TITLE
Refactor WORKSPACE repository dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,97 +32,10 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-# Google Absail.
-http_archive(
-    name = "com_google_absl",
-    sha256 = "3ea49a7d97421b88a8c48a0de16c16048e17725c7ec0f1d3ea2683a2a75adc21",
-    strip_prefix = "abseil-cpp-20230125.0",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.0.tar.gz"],
-)
+load("//:repos.bzl", "mpact_sim_repos")
 
-# Google protobuf.
-http_archive(
-    name = "com_google_protobuf",
-    sha256 = "4eab9b524aa5913c6fffb20b2a8abf5ef7f95a80bc0701f3a6dbb4c607f73460",
-    strip_prefix = "protobuf-3.21.12",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protobuf-cpp-3.21.12.tar.gz"],
-)
+mpact_sim_repos()
 
-# Bazel rules for proto.
-http_archive(
-    name = "rules_proto_grpc",
-    sha256 = "fb7fc7a3c19a92b2f15ed7c4ffb2983e956625c1436f57a3430b897ba9864059",
-    strip_prefix = "rules_proto_grpc-4.3.0",
-    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.3.0.tar.gz"],
-)
+load("//:deps.bzl", "mpact_sim_deps")
 
-load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")
-
-rules_proto_grpc_toolchains()
-
-rules_proto_grpc_repos()
-
-# Google test.
-http_archive(
-    name = "com_google_googletest",
-    sha256 = "ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363",
-    strip_prefix = "googletest-1.13.0",
-    urls = ["https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz"],
-)
-
-# ELFIO header based library.
-http_archive(
-    name = "com_github_serge1_elfio",
-    build_file = "BUILD.elfio",
-    sha256 = "767b269063fc35aba6d361139f830aa91c45dc6b77942f082666876c1aa0be0f",
-    strip_prefix = "elfio-3.9",
-    urls = ["https://github.com/serge1/ELFIO/releases/download/Release_3.9/elfio-3.9.tar.gz"],
-)
-
-# Antlr4 c++ runtime.
-http_archive(
-    name = "org_antlr4_cpp_runtime",
-    build_file = "BUILD.antlr4",
-    sha256 = "8018c335316e61bb768e5bd4a743a9303070af4e1a8577fa902cd053c17249da",
-    urls = ["https://www.antlr.org/download/antlr4-cpp-runtime-4.11.1-source.zip"],
-)
-
-# Antlr4 tool (java).
-http_file(
-    name = "org_antlr_tool",
-    sha256 = "62975e192b4af2622b72b5f0131553ee3cbce97f76dc2a41632dcc55e25473e1",
-    url = "https://www.antlr.org/download/antlr-4.11.1-complete.jar",
-)
-
-# Binding to tool targets in mpact-sim. This is required for the macros
-# in mpact_sim_isa.bzl to work properly when generating code for the
-# decoders. These create the //external:decoder_gen and
-# //external:bin_format_gen aliases used in mpact_sim_isa.bzl.
-bind(
-    name = "decoder_gen",
-    actual = "//mpact/sim/decoder:decoder_gen",
-)
-
-bind(
-    name = "bin_format_gen",
-    actual = "//mpact/sim/decoder:bin_format_gen",
-)
-
-# Additional rules for building non-bazel projects. Antlr4 builds using cmake.
-http_archive(
-    name = "rules_foreign_cc",
-    sha256 = "2a4d07cd64b0719b39a7c12218a3e507672b82a97b98c6a89d38565894cf7c51",
-    strip_prefix = "rules_foreign_cc-0.9.0",
-    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz",
-)
-
-load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
-
-rules_foreign_cc_dependencies()
-
-# Additional rules for licenses
-http_archive(
-    name = "rules_license",
-    sha256 = "6157e1e68378532d0241ecd15d3c45f6e5cfd98fc10846045509fb2a7cc9e381",
-    url = "https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz",
-)
+mpact_sim_deps()

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,0 +1,27 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Set up extra repositories with the dependencies"""
+
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")
+
+def mpact_sim_deps():
+    """ Extra dependencies to finish setting up Google repositories"""
+
+    rules_foreign_cc_dependencies()
+
+    rules_proto_grpc_toolchains()
+
+    rules_proto_grpc_repos()

--- a/mpact/sim/decoder/BUILD
+++ b/mpact/sim/decoder/BUILD
@@ -65,16 +65,12 @@ mpact_cc_library(
     deps = [
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings",
-        "@org_antlr4_cpp_runtime//:antlr4",
     ],
 )
 
 mpact_cc_library(
     name = "antlr_parser_wrapper",
     hdrs = ["antlr_parser_wrapper.h"],
-    deps = [
-        "@org_antlr4_cpp_runtime//:antlr4",
-    ],
 )
 
 mpact_cc_library(
@@ -123,7 +119,6 @@ mpact_cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
-        "@org_antlr4_cpp_runtime//:antlr4",
     ],
 )
 
@@ -225,7 +220,6 @@ mpact_cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
-        "@org_antlr4_cpp_runtime//:antlr4",
     ],
 )
 

--- a/mpact/sim/decoder/mpact_sim_isa.bzl
+++ b/mpact/sim/decoder/mpact_sim_isa.bzl
@@ -26,7 +26,7 @@ def mpact_cc_library(name, srcs = [], hdrs = [], copts = [], deps = [], features
         srcs = srcs,
         hdrs = hdrs,
         copts = copts + ["-iquote $(BINDIR)/external/org_antlr4_cpp_runtime/antlr4/include/antlr4-runtime"],
-        deps = deps,
+        deps = deps + ["@org_antlr4_cpp_runtime//:antlr4"],
         visibility = visibility,
         features = features,
     )
@@ -36,7 +36,7 @@ def mpact_cc_binary(name, srcs = [], copts = [], deps = [], features = [], visib
         name = name,
         srcs = srcs,
         copts = copts + ["-iquote $(BINDIR)/external/org_antlr4_cpp_runtime/antlr4/include/antlr4-runtime"],
-        deps = deps,
+        deps = deps + ["@org_antlr4_cpp_runtime//:antlr4"],
         visibility = visibility,
         features = features,
     )
@@ -47,7 +47,7 @@ def mpact_cc_test(name, size = "small", srcs = [], deps = [], copts = [], data =
         size = size,
         copts = copts + ["-iquote $(BINDIR)/external/org_antlr4_cpp_runtime/antlr4/include/antlr4-runtime"],
         srcs = srcs,
-        deps = deps,
+        deps = deps + ["@org_antlr4_cpp_runtime//:antlr4"],
         data = data,
     )
 
@@ -92,7 +92,7 @@ def mpact_isa_decoder(name, src, includes, deps = [], isa_name = "", prefix = ""
         outs = out_files,
         cmd = command,
         heuristic_label_expansion = 0,
-        tools = ["//external:decoder_gen"],
+        tools = ["@@com_google_mpact-sim//mpact/sim/decoder:decoder_gen"],
     )
 
     # The rule for the lib that is built from the generated sources.
@@ -101,8 +101,8 @@ def mpact_isa_decoder(name, src, includes, deps = [], isa_name = "", prefix = ""
         srcs = [f for f in out_files if f.endswith(".cc")],
         hdrs = [f for f in out_files if f.endswith(".h")],
         deps = [
-            Label("//mpact/sim/generic:arch_state"),
-            Label("//mpact/sim/generic:instruction"),
+            "@@com_google_mpact-sim//mpact/sim/generic:arch_state",
+            "@@com_google_mpact-sim//mpact/sim/generic:instruction",
             "@com_google_absl//absl/container:flat_hash_map",
             "@com_google_absl//absl/strings:str_format",
         ] + deps,
@@ -147,7 +147,7 @@ def mpact_bin_fmt_decoder(name, src, includes, deps = [], decoder_name = "", pre
         outs = out_files,
         cmd = command,
         heuristic_label_expansion = 0,
-        tools = ["//external:bin_format_gen"],
+        tools = ["@@com_google_mpact-sim//mpact/sim/decoder:bin_format_gen"],
     )
 
     # The rule for the lib that is built from the generated sources.
@@ -156,8 +156,8 @@ def mpact_bin_fmt_decoder(name, src, includes, deps = [], decoder_name = "", pre
         srcs = [f for f in out_files if f.endswith(".cc")],
         hdrs = [f for f in out_files if f.endswith(".h")],
         deps = [
-            Label("//mpact/sim/generic:arch_state"),
-            Label("//mpact/sim/generic:instruction"),
+            "@@com_google_mpact-sim//mpact/sim/generic:arch_state",
+            "@@com_google_mpact-sim//mpact/sim/generic:instruction",
             "@com_google_absl//absl/container:flat_hash_map",
             "@com_google_absl//absl/functional:any_invocable",
             "@com_google_absl//absl/strings:str_format",
@@ -175,7 +175,7 @@ def _strip_path(text):
 # those that will be included, the command includes creating a bash array from $(SRCS), then
 # instead of using $(SRCS) in the command, it uses only the first element of that array.
 def _make_isa_tool_invocation_command(prefix, isa_name):
-    cmd = "ARR=($(SRCS)); $(location //external:decoder_gen) " + \
+    cmd = "ARR=($(SRCS)); $(location @@com_google_mpact-sim//mpact/sim/decoder:decoder_gen) " + \
           "$${ARR[0]}" + \
           " --prefix " + prefix + \
           " --output_dir $(@D)"
@@ -187,7 +187,7 @@ def _make_isa_tool_invocation_command(prefix, isa_name):
 # those that will be included, the command includes creating a bash array from $(SRCS), then
 # instead of using $(SRCS) in the command, it uses only the first element of that array.
 def _make_bin_tool_invocation_command(prefix, decoder_name):
-    cmd = "ARR=($(SRCS)); $(location //external:bin_format_gen) " + \
+    cmd = "ARR=($(SRCS)); $(location @@com_google_mpact-sim//mpact/sim/decoder:bin_format_gen) " + \
           "$${ARR[0]}" + \
           " --prefix " + prefix + \
           " --output_dir $(@D)"

--- a/repos.bzl
+++ b/repos.bzl
@@ -1,0 +1,107 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Load dependent repositories"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+
+def mpact_sim_repos():
+    """ Load dependencies needed to use mpact-sim as a 3rd-party consumer"""
+
+    # Google Absail.
+    if not native.existing_rule("com_google_absl"):
+        http_archive(
+            name = "com_google_absl",
+            sha256 = "3ea49a7d97421b88a8c48a0de16c16048e17725c7ec0f1d3ea2683a2a75adc21",
+            strip_prefix = "abseil-cpp-20230125.0",
+            urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.0.tar.gz"],
+        )
+
+    # Google protobuf.
+    if not native.existing_rule("com_google_protobuf"):
+        http_archive(
+            name = "com_google_protobuf",
+            sha256 = "4eab9b524aa5913c6fffb20b2a8abf5ef7f95a80bc0701f3a6dbb4c607f73460",
+            strip_prefix = "protobuf-3.21.12",
+            urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protobuf-cpp-3.21.12.tar.gz"],
+        )
+
+    # Bazel rules for proto.
+    if not native.existing_rule("rules_proto_grpc"):
+        http_archive(
+            name = "rules_proto_grpc",
+            sha256 = "fb7fc7a3c19a92b2f15ed7c4ffb2983e956625c1436f57a3430b897ba9864059",
+            strip_prefix = "rules_proto_grpc-4.3.0",
+            urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.3.0.tar.gz"],
+        )
+
+    # Google test.
+    if not native.existing_rule("com_google_googletest"):
+        http_archive(
+            name = "com_google_googletest",
+            sha256 = "ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363",
+            strip_prefix = "googletest-1.13.0",
+            urls = ["https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz"],
+        )
+
+    # Transitive dependencies of googletest. Need to list explicitly for v1.13.0.
+    # Can load as deps in a later version.
+    if not native.existing_rule("com_googlesource_code_re2"):
+        http_archive(
+            name = "com_googlesource_code_re2",  # 2022-12-21T14:29:10Z
+            sha256 = "b9ce3a51beebb38534d11d40f8928d40509b9e18a735f6a4a97ad3d014c87cb5",
+            strip_prefix = "re2-d0b1f8f2ecc2ea74956c7608b6f915175314ff0e",
+            urls = ["https://github.com/google/re2/archive/d0b1f8f2ecc2ea74956c7608b6f915175314ff0e.zip"],
+        )
+
+    # Additional rules for building non-bazel projects. Antlr4 builds using cmake.
+    if not native.existing_rule("rules_foreign_cc"):
+        http_archive(
+            name = "rules_foreign_cc",
+            sha256 = "2a4d07cd64b0719b39a7c12218a3e507672b82a97b98c6a89d38565894cf7c51",
+            strip_prefix = "rules_foreign_cc-0.9.0",
+            url = "https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz",
+        )
+
+    # Additional rules for licenses
+    if not native.existing_rule("rules_license"):
+        http_archive(
+            name = "rules_license",
+            sha256 = "6157e1e68378532d0241ecd15d3c45f6e5cfd98fc10846045509fb2a7cc9e381",
+            url = "https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz",
+        )
+
+    # ELFIO header based library.
+    http_archive(
+        name = "com_github_serge1_elfio",
+        build_file = "@@com_google_mpact-sim//:external/BUILD.elfio",
+        sha256 = "767b269063fc35aba6d361139f830aa91c45dc6b77942f082666876c1aa0be0f",
+        strip_prefix = "elfio-3.9",
+        urls = ["https://github.com/serge1/ELFIO/releases/download/Release_3.9/elfio-3.9.tar.gz"],
+    )
+
+    # Antlr4 tool (java).
+    http_file(
+        name = "org_antlr_tool",
+        sha256 = "62975e192b4af2622b72b5f0131553ee3cbce97f76dc2a41632dcc55e25473e1",
+        url = "https://www.antlr.org/download/antlr-4.11.1-complete.jar",
+    )
+
+    # Antlr4 c++ runtime.
+    http_archive(
+        name = "org_antlr4_cpp_runtime",
+        build_file = "@com_google_mpact-sim//:external/BUILD.antlr4",
+        sha256 = "8018c335316e61bb768e5bd4a743a9303070af4e1a8577fa902cd053c17249da",
+        urls = ["https://www.antlr.org/download/antlr4-cpp-runtime-4.11.1-source.zip"],
+    )


### PR DESCRIPTION
Create {repos, deps} macros for the dependencies, so the downstream project can use the macros directly instead of maintaining a long WORKSPACE list
(See
https://bazel.build/external/overview#shortcomings_of_the_workspace_system)

Also cleanup mpact_sim_isa.bzl to use the canonical repo references so we don't need to apply the binding hack.
https://bazel.build/external/overview#canonical_repository_name