### PR TITLE
Include files in the directory of src

### DIFF
--- a/mpact/sim/decoder/mpact_sim_isa.bzl
+++ b/mpact/sim/decoder/mpact_sim_isa.bzl
@@ -273,7 +273,7 @@ def _make_isa_tool_invocation_command(num_srcs, prefix, isa_name):
     # Add the sources that are not in includes.
     for i in range(0, num_srcs):
         cmd += "$${ARR[" + str(i) + "]} "
-    cmd += "--prefix " + prefix + " --output_dir $(@D)"
+    cmd += "--prefix " + prefix + " --output_dir $(@D) --include $$(dirname $${ARR[0]})"
     if isa_name != "":
         cmd += " --isa_name " + isa_name
 
@@ -288,7 +288,7 @@ def _make_bin_tool_invocation_command(num_srcs, prefix, decoder_name):
     # Add the sources that are not in includes.
     for i in range(0, num_srcs):
         cmd += "$${ARR[" + str(i) + "]} "
-    cmd += " --prefix " + prefix + " --output_dir $(@D)"
+    cmd += " --prefix " + prefix + " --output_dir $(@D) --include $$(dirname $${ARR[0]})"
     if decoder_name != "":
         cmd += " --decoder_name " + decoder_name
     return cmd


### PR DESCRIPTION
mpact_isa_decoder() and mpact_bin_fmt_decoder() uses the working directory to find files to include, but it is unreliable the working directory will vary if the repository containing the source files is nested.

To avoid this unreliability, always include files in the directory of src.

See also: https://github.com/akihikodaki/mpact-riscv/commit/6520b5ecccb6d9b99f7289c2a9671f7812bfcda4